### PR TITLE
Fix evaluate() to reset iterator if !hasNext()

### DIFF
--- a/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java
+++ b/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java
@@ -2350,6 +2350,9 @@ public class ComputationGraph implements Serializable, Model {
         if (layers == null || !(getOutputLayer(0) instanceof IOutputLayer)) {
             throw new IllegalStateException("Cannot evaluate network with no output layer");
         }
+        
+        if (!iterator.hasNext()) 
+            iterator.reset();
 
         if (labelsList == null)
             labelsList = iterator.getLabels();


### PR DESCRIPTION
If a user is evaluating data multiple times over the course of training, he or she will likely not know that their iterator needs a reset. This PR addresses that.